### PR TITLE
Update styles for iframe tag

### DIFF
--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -9,6 +9,13 @@ body {
   line-height: 1.6em;
 }
 
+iframe {
+  max-width: 100%;
+  width: 90%;
+  margin: 1em auto;
+  display: block;
+}
+
 footer {
   margin: 40px 0 0 !important;
   padding: 0 !important;


### PR DESCRIPTION
close issue #28
Kotlin playgroundの埋め込みでしか確認していないので、他のiframeの埋め込みに悪影響が起こる可能性はある。
しかし、特に何かを指定しているわけでもないのになぜキレイに横幅300pxになっていたのかはよくわからない。