### PR TITLE
Fix script to delete unnecessary branches

### DIFF
--- a/scripts/delete-merged-branch.sh
+++ b/scripts/delete-merged-branch.sh
@@ -2,6 +2,6 @@
 
 # refer: https://gist.github.com/miukoba/fc3c10a25c1c675c1e97
 
-git branch --merged master | grep -vE '^\*|master$' | xargs -I % git branch -d %
-git branch -r --merged master | grep -v -e master | sed -e 's% *origin/%%' | xargs -I% git push --delete origin %
+git branch --merged master | grep -vE '^\*|\<master\>' | xargs -I % git branch -d %
+git branch -r --merged master | grep -vE '\<master\>' | sed -e 's% *origin/%%' | xargs -I% git push --delete origin %
 git fetch --prune


### PR DESCRIPTION
前のscriptでは`fix_master`などmasterで終わるブランチ名が削除対象から漏れていた
正規表現を`^master$`にすればいいかというと、これだと先頭に空白が入っている場合に除外しきれない
`\<`は以降の文字で始まる、を表す正規表現
(逆はその前の文字で終わるを意味する)
更新後の正規表現でmasterのみを除外できるようになった